### PR TITLE
Return eduPersonTargetedID as well

### DIFF
--- a/src/saml/User.php
+++ b/src/saml/User.php
@@ -18,7 +18,8 @@ class User
             'eduPersonPrincipalName' => [
                 $username . '@' . $idpDomainName,
             ],
-            'eduPersonTargetID' => (array)$uuid,
+            'eduPersonTargetID' => (array)$uuid, // Incorrect, deprecated
+            'eduPersonTargetedID' => (array)$uuid,
             'sn' => (array)$lastName,
             'givenName' => (array)$firstName,
             'mail' => (array)$email,


### PR DESCRIPTION
This will let us transition any existing systems to use the (correct)
eduPersonTargetedID rather than the (incorrect) eduPersonTargetID.