### PR TITLE
Stop returning eduPersonTargetedID

### DIFF
--- a/src/saml/User.php
+++ b/src/saml/User.php
@@ -19,7 +19,10 @@ class User
                 $username . '@' . $idpDomainName,
             ],
             'eduPersonTargetID' => (array)$uuid, // Incorrect, deprecated
-            'eduPersonTargetedID' => (array)$uuid,
+            
+            // DO NOT INCLUDE until we can format it as a saml:NameID element.
+            //'eduPersonTargetedID' => (array)$uuid,
+            
             'sn' => (array)$lastName,
             'givenName' => (array)$firstName,
             'mail' => (array)$email,


### PR DESCRIPTION
At the moment, returning it causes SimpleSAMLphp to throw an
exception since the eduPersonTargetedID is not formatted as a
saml:NameID element in the SAML assertion XML.