### PR TITLE
Release 4.0.8

### DIFF
--- a/src/saml/User.php
+++ b/src/saml/User.php
@@ -19,7 +19,10 @@ class User
                 $username . '@' . $idpDomainName,
             ],
             'eduPersonTargetID' => (array)$uuid, // Incorrect, deprecated
-            'eduPersonTargetedID' => (array)$uuid,
+            
+            // DO NOT INCLUDE until we can format it as a saml:NameID element.
+            //'eduPersonTargetedID' => (array)$uuid,
+            
             'sn' => (array)$lastName,
             'givenName' => (array)$firstName,
             'mail' => (array)$email,


### PR DESCRIPTION
Fixed:
- Stop returning eduPersonTargetedID since it ends up misformatted in the SAML assertion XML and causes an exception to be thrown at the SP