### PR TITLE
Release 4.1.0

### DIFF
--- a/src/saml/User.php
+++ b/src/saml/User.php
@@ -37,6 +37,7 @@ class User
             'cn' => (array)$username,
             'schacExpiryDate' => (array)$passwordExpirationDate,
             'mfa' => $mfa,
+            'uuid' => (array)$uuid,
         ];
     }
 }

--- a/src/saml/User.php
+++ b/src/saml/User.php
@@ -18,10 +18,17 @@ class User
             'eduPersonPrincipalName' => [
                 $username . '@' . $idpDomainName,
             ],
+            
+            /**
+             * Misspelled version of eduPersonTargetedID.
+             * @deprecated
+             */
             'eduPersonTargetID' => (array)$uuid, // Incorrect, deprecated
             
-            // DO NOT INCLUDE until we can format it as a saml:NameID element.
-            //'eduPersonTargetedID' => (array)$uuid,
+            /**
+             * NOTE: Do NOT include eduPersonTargetedID. If you need it, use the core:TargetedID module, ideally at the
+             *       Hub, to generate an eduPersonTargetedID.
+             */
             
             'sn' => (array)$lastName,
             'givenName' => (array)$firstName,

--- a/src/saml/User.php
+++ b/src/saml/User.php
@@ -26,8 +26,9 @@ class User
             'eduPersonTargetID' => (array)$uuid, // Incorrect, deprecated
             
             /**
-             * NOTE: Do NOT include eduPersonTargetedID. If you need it, use the core:TargetedID module, ideally at the
-             *       Hub, to generate an eduPersonTargetedID.
+             * NOTE: Do NOT include eduPersonTargetedID. If you need it, use the
+             * core:TargetedID module (at the Hub, if using one) to generate an
+             * eduPersonTargetedID.
              */
             
             'sn' => (array)$lastName,


### PR DESCRIPTION
**Summary:**
- Include the user's `uuid` attribute, intended to be used by the core:TargetedID auth proc to generate an eduPersonTargetedID