### PR TITLE
Populate 'member' SAML attribute

### DIFF
--- a/src/auth/IdBroker.php
+++ b/src/auth/IdBroker.php
@@ -89,7 +89,8 @@ class IdBroker
             $userInfo['mfa'],
             $userInfo['method'],
             $userInfo['manager_email'] ?? null,
-            $userInfo['profile_review'] ?? 'no'
+            $userInfo['profile_review'] ?? 'no',
+            $userInfo['member'] ?? []
         );
     }
     

--- a/src/saml/User.php
+++ b/src/saml/User.php
@@ -15,7 +15,8 @@ class User
         array $mfa,
         array $method,
         $managerEmail,
-        $profileReview
+        $profileReview,
+        array $member
     ) {
         return [
             'eduPersonPrincipalName' => [
@@ -45,6 +46,7 @@ class User
             'uuid' => (array)$uuid,
             'manager_email' => [$managerEmail ?? ''],
             'profile_review' => [$profileReview],
+            'member' => $member,
         ];
     }
 }


### PR DESCRIPTION
Transfer `member` property from ID Broker response into the SAML attribute by the same name.