### PR TITLE
change auth logs to include all IPs, not just untrusted

### DIFF
--- a/lib/Auth/Source/SilAuth.php
+++ b/lib/Auth/Source/SilAuth.php
@@ -122,7 +122,6 @@ class SilAuth extends UserPassBase
             $this->idBrokerConfig['assertValidIp'] ?? true
         );
         $request = new Request($this->getTrustedIpAddresses());
-        $untrustedIpAddresses = $request->getUntrustedIpAddresses();
         $userAgent = Request::getUserAgent() ?: '(unknown)';
         $authenticator = new Authenticator(
             $username,
@@ -140,7 +139,7 @@ class SilAuth extends UserPassBase
                 'username' => $username,
                 'errorCode' => $authError->getCode(),
                 'errorMessageParams' => $authError->getMessageParams(),
-                'ipAddresses' => join(',', $untrustedIpAddresses),
+                'ipAddresses' => join(',', $request->getIpAddresses()),
                 'userAgent' => $userAgent,
             ]));
             throw new Error([
@@ -153,7 +152,7 @@ class SilAuth extends UserPassBase
         $logger->warning(json_encode([
             'event' => 'User/pass authentication result: success',
             'username' => $username,
-            'ipAddresses' => join(',', $untrustedIpAddresses),
+            'ipAddresses' => join(',', $request->getIpAddresses()),
             'userAgent' => $userAgent,
         ]));
         

--- a/src/http/Request.php
+++ b/src/http/Request.php
@@ -53,7 +53,7 @@ class Request
      *
      * @return string[] A list of IP addresses.
      */
-    protected function getIpAddresses()
+    public function getIpAddresses()
     {
         $ipAddresses = [];
         

--- a/src/tests/unit/http/DummyRequest.php
+++ b/src/tests/unit/http/DummyRequest.php
@@ -12,7 +12,7 @@ class DummyRequest extends Request
      *
      * @return string[] A list containing the dummy IP address.
      */
-    protected function getIpAddresses()
+    public function getIpAddresses()
     {
         return [$this->dummyIpAddress];
     }


### PR DESCRIPTION
Previously if a user succeeded or failed from a "trusted" IP the IP was not included in the logs.