### PR TITLE
Use the existing session, instead of trying to start a new one

### DIFF
--- a/www/loginuserpass.php
+++ b/www/loginuserpass.php
@@ -38,7 +38,7 @@ $errorParams = null;
 $username = null;
 $password = null;
 
-$csrfProtector = new CsrfProtector(Session::getSession());
+$csrfProtector = new CsrfProtector(Session::getSessionFromRequest());
 
 $globalConfig = Configuration::getInstance();
 $authSourcesConfig = $globalConfig->getConfig('authsources.php');


### PR DESCRIPTION
### Fixed
- Use the existing session, instead of accidentally trying to start a new one, so this does not die on PHP 7.4 with an error of "session_id(): Cannot change session id when session is active"

---

The other PR is still in progress, and includes many other fixes and some additional (and complicated) tests to prove this fix. However, it's getting too tangled for my liking, so I'm pushing this fix out first by itself.