### PR TITLE
Avoid versioning AES key files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.phar
 composer.lock
 codeship.aes
 codeship.env
+*.aes


### PR DESCRIPTION
### Fixed
- Protect against accidentally committing encryption keys to git