### PR TITLE
Update our FakeSession to match usages of real Session

### DIFF
--- a/src/tests/unit/csrf/CsrfProtectorTest.php
+++ b/src/tests/unit/csrf/CsrfProtectorTest.php
@@ -2,7 +2,6 @@
 namespace Sil\SilAuth\tests\unit\csrf;
 
 use Sil\SilAuth\csrf\CsrfProtector;
-use Sil\SilAuth\tests\unit\csrf\FakeSession;
 use PHPUnit\Framework\TestCase;
 
 class CsrfProtectorTest extends TestCase
@@ -10,7 +9,7 @@ class CsrfProtectorTest extends TestCase
     public function testChangeMasterToken()
     {
         // Arrange:
-        $csrfProtector = new CsrfProtector(FakeSession::getSession());
+        $csrfProtector = new CsrfProtector(FakeSession::getSessionFromRequest());
         $firstToken = $csrfProtector->getMasterToken();
         $firstTokenAgain = $csrfProtector->getMasterToken();
         

--- a/src/tests/unit/csrf/FakeSession.php
+++ b/src/tests/unit/csrf/FakeSession.php
@@ -25,7 +25,7 @@ class FakeSession extends \SimpleSAML\Session
         return $this->inMemoryDataStore[$type][$id] ?? null;
     }
     
-    public static function getSession($sessionId = null)
+    public static function getSessionFromRequest($sessionId = null)
     {
         return new self();
     }


### PR DESCRIPTION
### Fixed
- Change usage of our FakeSession to also call `getSessionFromRequest()`